### PR TITLE
docs: add security nfr set

### DIFF
--- a/docs/security-nfr/NFR.md
+++ b/docs/security-nfr/NFR.md
@@ -1,0 +1,13 @@
+# Security Non-Functional Requirements (Wishlist API)
+
+| ID | Название | Описание | Метрика / Порог | Проверка (чем/где) | Компонент | Приоритет |
+| --- | --- | --- | --- | --- | --- | --- |
+| NFR-01 | Хэширование паролей | Учетные записи пользователей хранятся только в виде стойких хэшей | PBKDF2-HMAC-SHA256, 130k итераций, соль 16B | Юнит-тест `test_security_hash_params`, код-ревью | Auth сервис | High |
+| NFR-02 | TTL access-токена | Скомпрометированный токен должен перестать работать в разумный срок | TTL access token ≤ 15 минут, refresh отключён | Pytest сценарии + конфиг FastAPI | Auth сервис | Medium |
+| NFR-03 | Brute-force защита логина | Ограничить количество неуспешных логинов с одного IP/email | Не более 5 fail/min на пользователя, 429 далее | E2E тест + future rate-limit middleware | API шлюз | High |
+| NFR-04 | Owner-only доступ | Пользователь не может читать/менять чужие wishes | 100% CRUD эндпойнтов возвращают 404/403 при чужом ID | Контрактные тесты `tests/test_wishes.py` | Wish сервис | High |
+| NFR-05 | Формат ошибок | Все ошибки в JSON-обёртке с `error.code` и `request_id` | 100% эндпойнтов → формат как в README | Pytest snapshot + middleware логирования | API слой | Medium |
+| NFR-06 | Латентность `/api/v1/wishes` | Сервис должен отвечать быстро при рабочих нагрузках | p95 ≤ 400 мс @ 30 RPS, p99 ≤ 800 мс | k6 нагрузочный тест на stage | Wish сервис | Medium |
+| NFR-07 | Уязвимости зависимостей | Критические CVE устраняются оперативно | High/Critical в SBOM закрываются ≤ 7 дней | CI: `pip-audit`/`gh advisories` | Build pipeline | High |
+| NFR-08 | Логи аудита | Каждая операция CRUD пишется в audit log с request_id и owner_id | ≥ 1 запись на запрос, хранение 90 дней | Observability stack + pytest мок | Logging слой | Medium |
+| NFR-09 | Бэкапы wish data | Потеря данных не более 24 часов | Ежедневные snapshot’ы, проверка восстановления еженедельно | Backup job + runbook | БД | Medium |

--- a/docs/security-nfr/NFR_BDD.md
+++ b/docs/security-nfr/NFR_BDD.md
@@ -1,0 +1,39 @@
+# Security NFR Acceptance (BDD)
+
+```gherkin
+Feature: Безопасная аутентификация
+  Scenario: Пароли хэшируются устойчивым алгоритмом
+    Given существует новый пользователь с паролем "Password123!"
+    When он регистрируется через POST /api/v1/auth/signup
+    Then запись в users хранит пароль в формате pbkdf2$130000$<salt>$<digest>
+    And параметр iterations равен 130000 или выше
+
+  Scenario: Access-токен истекает в течение 15 минут
+    Given пользователь получает токен через POST /api/v1/auth/login
+    When проходит 16 минут без refresh
+    Then повторный вызов защищённого эндпойнта возвращает ошибку auth_error
+
+Feature: Owner-only доступ к Wish
+  Scenario: Владельца не пускают к чужому ресурсу
+    Given пользователь Alice создал wish #123
+    And пользователь Bob авторизован с другим токеном
+    When Bob запрашивает GET /api/v1/wishes/123
+    Then API отвечает 404 not_found
+
+  Scenario: Админ видит чужие данные в целях модерации
+    Given wish принадлежит Alice
+    And существует администратор с ролью admin
+    When админ делает GET /api/v1/wishes/123
+    Then API отвечает 200 и содержит поле owner_id=Alice
+
+Feature: Обработка ошибок в едином формате
+  Scenario: Ошибка валидации возвращает envelope
+    Given пользователь отправляет POST /api/v1/wishes без title
+    When API валидирует payload
+    Then ответ имеет статус 422 и JSON {"error": {"code": "validation_error", "message": "..."}}
+
+  Scenario: request_id логируется для каждой операции
+    Given сервис обрабатывает PATCH /api/v1/wishes/456
+    When middleware присваивает request_id
+    Then в логах появляется запись с тем же request_id и статусом ответа
+```

--- a/docs/security-nfr/NFR_TRACEABILITY.md
+++ b/docs/security-nfr/NFR_TRACEABILITY.md
@@ -1,0 +1,13 @@
+# NFR Traceability Matrix
+
+| NFR ID | Story / Task | Компонент | Приоритет | Release Window | Примечание |
+| --- | --- | --- | --- | --- | --- |
+| NFR-01 | AUTH-10: Реализовать PBKDF2 хэширование | Auth | High | P04 | покрыто текущим кодом `shared/security.py` |
+| NFR-02 | AUTH-15: Управление TTL access-токенов | Auth | Medium | P05 | потребует конфигурации redis/session store |
+| NFR-03 | API-21: Rate-limit логина | API gateway | High | P06 | интеграция с FastAPI middleware + Redis |
+| NFR-04 | WISH-08: Owner-only CRUD | Wish service | High | P02 | покрыто тестами `tests/test_wishes.py` |
+| NFR-05 | OBS-03: Единый формат ошибок и request_id | API layer | Medium | P07 | нужен middleware логирования |
+| NFR-06 | PERF-04: Нагрузочный тест wishlist | Wish service | Medium | P08 | сценарии k6 в infra repo |
+| NFR-07 | SEC-12: Мониторинг зависимостей (SCA) | CI/CD | High | P05 | добавить шаг pip-audit в workflow |
+| NFR-08 | OBS-05: Audit log операций | Logging | Medium | P09 | связка с ELK/OTEL, храним ≥90 дней |
+| NFR-09 | DB-02: Бэкап Postgres | Database | Medium | P10 | автоматизированный snapshot в S3 |


### PR DESCRIPTION
## Контекст
По практике P03 сформирован набор security NFR для сервиса Wishlist (docs/security-nfr/NFR.md). Нужно завести работы и привязать NFR к конкретным задачам/релизам.

## Что сделано
- завела каталог docs/security-nfr/ с тремя артефактами:
NFR.md — 9 измеримых требований (PBKDF2, TTL токена, rate-limit, owner-only, формат ошибок, перф, SCA, аудит-логи, бэкапы)
NFR_BDD.md — 6 Gherkin-сценариев для ключевых NFR, включая негативные (истечение токена, запрос к чужому wish)
NFR_TRACEABILITY.md — матрица NFR ↔ Stories/Tasks с приоритетом и релизным окном (P04–P10)
- создала Issue “NFR report” и расписала туда NFR-ID 

## Как проверял(а)
- [x] `ruff/black/isort` локально
- [x] `pytest -q` зелёный
- [x] `pre-commit run --all-files`

issue https://github.com/rkarkarkarka/SECDEV_hw/issues/7#issue-3744811107